### PR TITLE
Minimal copying when reading subblocks, and allow reading a frame range.

### DIFF
--- a/src/gif.js
+++ b/src/gif.js
@@ -233,11 +233,19 @@ GIF.prototype.decompressFrame = function(index, buildPatch){
 };
 
 // returns all frames decompressed
-GIF.prototype.decompressFrames = function(buildPatch){
+GIF.prototype.decompressFrames = function(buildPatch, startFrame, endFrame){
+	if (startFrame === undefined) {
+		startFrame = 0;
+	}
+	if (endFrame === undefined) {
+		endFrame = this.raw.frames.length;
+	} else {
+		endFrame = Math.min(endFrame, this.raw.frames.length);
+	}
 	var frames = [];
-	for(var i=0; i<this.raw.frames.length; i++){
+	for (var i = startFrame; i < endFrame; i++) {
 		var frame = this.raw.frames[i];
-		if(frame.image){
+		if (frame.image) {
 			frames.push(this.decompressFrame(i, buildPatch));
 		}
 	}

--- a/src/schema.js
+++ b/src/schema.js
@@ -9,10 +9,18 @@ var Parsers = require('../bower_components/js-binary-schema-parser/src/parsers')
 var subBlocks = {
 	label: 'blocks',
 	parser: function(stream){
-		var out = [];
+		var views = [];
+		var total = 0;
 		var terminator = 0x00;		
 		for(var size=stream.readByte(); size!==terminator; size=stream.readByte()){
-			out = out.concat(stream.readBytes(size));
+			views.push(stream.readBytes(size));
+			total += size;
+		}
+		var out = new Uint8Array(total);
+		total = 0;
+		for (var i = 0; i < views.length; i++) {
+			out.set(views[i], total);
+			total += views[i].length;
 		}
 		return out;
 	}


### PR DESCRIPTION
This adds compatibility with https://github.com/matt-way/jsBinarySchemaParser/pull/2

I also had a gif I was using which ping-ponged, so I just wanted to decompress half of it. I added a couple of arguments to the decompressFrames method. Maybe should have been a seperate PR but I'm not very good at planning my commits for these things.