### PR TITLE
fix(types): use Uint8ClampedArray instead of number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ export type ParsedFrame = {
   colorTable: [number, number, number][]
   delay: number
   disposalType: number
-  patch: Uint8ClampedArray[]
+  patch: Uint8ClampedArray
   pixels: number[]
   transparentIndex: number
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ export type ParsedFrame = {
   colorTable: [number, number, number][]
   delay: number
   disposalType: number
-  patch: number[]
+  patch: Uint8ClampedArray[]
   pixels: number[]
   transparentIndex: number
 }


### PR DESCRIPTION
`Uint8ClampedArray` can be converted to `ArrayBuffer` but `number[]` doesn't allow do that