### PR TITLE
TypeScript: decompressFrame function declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,3 +87,15 @@ export function decompressFrames(
   parsedGif: ParsedGif,
   buildImagePatches: false
 ): ParsedFrameWithoutPatch[]
+
+export function decompressFrame(
+  frame: Frame,
+  gct: [number, number, number][],
+  buildImagePatches: true
+): ParsedFrame
+
+export function decompressFrame(
+  frame: Frame,
+  gct: [number, number, number][],
+  buildImagePatches: false
+): ParsedFrameWithoutPatch


### PR DESCRIPTION
These methods are useful in cases where decompression needs to be done piecemeal, and not all at once. In my case, I was writing an asynchronous GIF loader. Exposing them as declarations just helps avoid some TypeScript warnings.

If they're meant to be private / internal though, it makes sense to keep these obscured and out of the declaration file. No hard feelings if this PR is not accepted 😄 