### PR TITLE
Correct use of disposalType in demo

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -195,14 +195,17 @@ function manipulate() {
   ctx.drawImage(c, 0, 0, pixelsX, pixelsY, 0, 0, c.width, c.height)
 }
 
+var needsDisposal = false
+
 function renderFrame() {
   // get the frame
   var frame = loadedFrames[frameIndex]
 
   var start = new Date().getTime()
   
-  if (frame.disposalType ===  2) {
+  if (needsDisposal) {
     gifCtx.clearRect(0, 0, c.width, c.height)
+    needsDisposal = false
   }
 
   // draw the patch
@@ -215,6 +218,10 @@ function renderFrame() {
   frameIndex++
   if (frameIndex >= loadedFrames.length) {
     frameIndex = 0
+  }
+  
+  if (frame.disposalType === 2) {
+    needsDisposal = true
   }
 
   var end = new Date().getTime()


### PR DESCRIPTION
See #35: `frame.disposalType` is used incorrectly in the demo, which had me scratching my head for a while today.