### PR TITLE
Make clear in readme that parser is not async

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ This decoder uses **[js-binary-schema-parser][5]** to parse the gif files (you c
 
         var promisedGif = fetch(gifURL)
              .then(resp => resp.arrayBuffer())
-             .then(buff => parseGIF(buff))
-             .then(gif => decompressFrames(gif, true));
+             .then(buff => {
+                 var gif = parseGIF(buff)
+                 var frames = decompressFrames(gif, true)
+                 return gif;
+             });
 
 - _XMLHttpRequest_
 


### PR DESCRIPTION
The readme implied that `parseGif` and `decompressFrames` are async by chaining them with `.then`, but they're sync.