### PR TITLE
Fix a GIF which failed to parse

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,6 @@ export const decompressFrame = (frame, gct, buildImagePatch) => {
 
 export const decompressFrames = (parsedGif, buildImagePatches) => {
   return parsedGif.frames
-    .filter(f => f.image)
+    .filter(f => !('application' in f))
     .map(f => decompressFrame(f, parsedGif.gct, buildImagePatches))
 }


### PR DESCRIPTION
The following GIF: https://media3.giphy.com/media/mdWGEU5Lo3pZe/giphy.gif

![image](https://user-images.githubusercontent.com/1629785/208070299-61b661e6-c852-4638-9d86-fcb0702337b6.png)


has `application` as well as `image`, but really is of type Application. It gets parsed as an image though, which results in a `delays` array of `[undefined, 100, 100, 100]`.

Inverting the filter condition fixes it!