### PR TITLE
Add a function to load gif frames progressively

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,3 +83,20 @@ export const decompressFrames = (parsedGif, buildImagePatches) => {
     .filter(f => f.image)
     .map(f => decompressFrame(f, parsedGif.gct, buildImagePatches))
 }
+
+// Decompress frames for time ms.  Return {processedFrames, remainingFrames}
+export const decompressFramesForDuration = (frames, parsedGif, buildImagePatches, time) => {
+  const endTime = performance.now() + time;
+  const processedFrames = [];
+  let index;
+  for (index = 0; index < frames.length && performance.now() < endTime; index++) {
+    const frame = frames[index];
+    if (frame.image) {
+      processedFrames.push(decompressFrame(frame, parsedGif.gct, buildImagePatches));
+    }
+  }
+  return {
+    processedFrames,
+    remainingFrames: frames.slice(index)
+  }
+}


### PR DESCRIPTION
We were having problems with gif loading impacting loading of other content since it happens on the main thread, so I created a function that can progressively decompress gif frames so we can space that out over multiple animation frames.